### PR TITLE
Making python3 explicit.

### DIFF
--- a/nodes/command_bridge_receiver_node.py
+++ b/nodes/command_bridge_receiver_node.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-from __future__ import print_function
 from builtins import str
 import rospy
 from std_msgs.msg import String

--- a/nodes/command_bridge_sender_node.py
+++ b/nodes/command_bridge_sender_node.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import rospy
 from std_msgs.msg import String


### PR DESCRIPTION
Making python3 explicit in shebang and removing `from __future__` and `from builtins` imports from `.py` files.

The reasons for this are...

1. For our use-case we are using ROS-Noetic (Python 3) with older code that is Python 2, so need to be explicit with the interpreter. 
2. Noetic is exclusively Python 3, so including the imports can be confusing.